### PR TITLE
Extend mkpath docstring

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -187,7 +187,8 @@ end
     mkpath(path::AbstractString; mode::Unsigned = 0o777)
 
 Create all directories in the given `path`, with permissions `mode`. `mode` defaults to
-`0o777`, modified by the current file creation mask.
+`0o777`, modified by the current file creation mask. This function ignores any errors
+if a directory in the given `path` already exists.
 Return `path`.
 
 # Examples


### PR DESCRIPTION
`mkpath` is set up in a way that it ignores any errors that `mkdir` would normally throw when a directory or subdirectory in the given `path` already exists.

This PR adds a clarification to `mkpath`'s docstring to tell users about this feature/behaviour.